### PR TITLE
node.fortran 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The `nodejs.f90` module exports the following subroutines:
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
+
 ## :sparkles: Related
 
  - [`fortran`](https://github.com/IonicaBizau/node-fortran)—Fortran bridge for Node.js which allows you to run Fortran code from Node.js.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "code"
   ],
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.